### PR TITLE
Fix credential acceptance in the pre-authorized code flow

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -26,8 +26,10 @@ spec:
     spec:
       securityContext:
         {{- include "app.securitycontext" . | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecrets }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -53,7 +53,7 @@ config:
   disableTLS: true
   country: DE
   region: EU
-  signerTopic: signer-topic
+  signerTopic: sign
   storageTopic: storage
   offeringTopic: offering
   offeringPolicy:

--- a/internal/services/processing.go
+++ b/internal/services/processing.go
@@ -287,7 +287,7 @@ func fetchCredentialData(tenantId string, row types.OfferingRow, acceptance type
 		},
 	}
 
-	if tok.AuthorizationDetails != nil {
+	if tok.AuthorizationDetails != nil && len(tok.AuthorizationDetails.CredentialIdentifiers) > 0 {
 		req.CredentialIdentifier = tok.AuthorizationDetails.CredentialIdentifiers[0]
 	} else {
 		credConfig := row.MetaData.CredentialConfigurationsSupported[row.Offering.Credentials[0]]

--- a/internal/services/storage.go
+++ b/internal/services/storage.go
@@ -82,26 +82,31 @@ func ClearOffering(tenantId string, requestId string, groupId string, acceptance
 		return nil, errors.New("no record found")
 	}
 
+	if !acceptance.Accept {
+		// A rejected offering only needs to be removed. Do not run the retrieval
+		// pipeline: it would redeem the single-use pre-authorized code and fetch
+		// a credential that is thrown away, and any failure in that pipeline
+		// (expired code, missing holder key) would block the rejection.
+		err = deleteRejectedOffering(tenantId, requestId, groupId, ctx)
+		if err != nil {
+			return nil, errors.Join(errors.New("failed to delete rejected offering"), err)
+		}
+		return nil, nil
+	}
+
 	response, err := fetchCredentialData(tenantId, offs[0], acceptance)
 
 	if err != nil {
 		return nil, err
 	}
 
-	if acceptance.Accept {
-		err = StoreCredential(tenantId, requestId, groupId, *response, nil, ctx)
-		if err != nil {
-			return nil, errors.Join(errors.New("failed to store accepted credential"), err)
-		}
-		err = updateOfferingStatus(tenantId, requestId, groupId, acceptance.Accept, ctx)
-		if err != nil {
-			return nil, errors.Join(errors.New("failed to update offering status"), err)
-		}
-	} else {
-		err = deleteRejectedOffering(tenantId, requestId, groupId, ctx)
-		if err != nil {
-			return nil, errors.Join(errors.New("failed to delete rejected offering"), err)
-		}
+	err = StoreCredential(tenantId, requestId, groupId, *response, nil, ctx)
+	if err != nil {
+		return nil, errors.Join(errors.New("failed to store accepted credential"), err)
+	}
+	err = updateOfferingStatus(tenantId, requestId, groupId, acceptance.Accept, ctx)
+	if err != nil {
+		return nil, errors.Join(errors.New("failed to update offering status"), err)
 	}
 
 	return response, nil


### PR DESCRIPTION
While integrating the OCM-W stack (deployed via eclipse-xfsc/smartdeployment) we found that accepting a credential offer could not complete. Three changes:

1. **Panic on empty `credential_identifiers`** — the authorization bridge returns `authorization_details` for single-configuration offers with an empty identifier list, and `fetchCredentialData` indexes into it unconditionally (`internal/services/processing.go`), crashing with `index out of range [0] with length 0` on every accept. Added a length guard so the format-based request path is used instead.

2. **`signerTopic: signer-topic` placeholder default** — no component subscribes to this topic; the signer service listens on `sign`, so every holder binding failed with `nats: no responders available for request`. Changed the default accordingly.

3. **Unconditional `imagePullSecrets` in the Helm template** — when `image.pullSecrets` is unset the entry renders with an empty name, which breaks strategic-merge patching of the deployment (`kubectl set env`/`kubectl apply` fail with `map does not contain declared merge key: name`). The block is now rendered only when a secret is configured.

With these changes (plus fixes in neighbouring components) we have the full offer → token → holder binding → credential flow working end to end against a smartdeployment-provisioned stack.